### PR TITLE
add chromedriver-helper gem in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ end
 
 group :test do
   gem 'capybara', '~> 2.15.2'
+  gem "chromedriver-helper"
   gem 'selenium-webdriver'
   gem 'capybara-selenium', '~> 0.0.6'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (9.0.0)
     autoprefixer-rails (9.2.0)
       execjs
@@ -74,6 +76,9 @@ GEM
       mime-types (>= 1.16)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.2.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     cloudinary (1.9.1)
       aws_cf_signer
       rest-client
@@ -140,6 +145,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.0)
     ipaddress (0.8.3)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -348,6 +354,7 @@ DEPENDENCIES
   capybara (~> 2.15.2)
   capybara-selenium (~> 0.0.6)
   carrierwave (~> 1.2)
+  chromedriver-helper
   cloudinary
   devise
   dotenv-rails
@@ -385,4 +392,4 @@ RUBY VERSION
    ruby 2.4.4p296
 
 BUNDLED WITH
-   1.16.4
+   1.16.6


### PR DESCRIPTION
There was the following error in my rake:

 1) Items user add a new object
     Failure/Error: visit root_path
     
     Selenium::WebDriver::Error::WebDriverError:
       unable to connect to chromedriver 127.0.0.1:9515
      ./spec/features/items_spec.rb:8:in block (2 levels) in <main>

this gem fixed this error.